### PR TITLE
No Spaces in envvar urls. New config location hint

### DIFF
--- a/httpresponsetime
+++ b/httpresponsetime
@@ -5,9 +5,12 @@ This is useful as a sort of final availability measurement.
 
 How to configure:
 [httpresponsetime]
-    env.urls http://www.google.com, http://www.yahoo.com/something
+    env.urls http://www.google.com,https://www.yahoo.com/something
 
-Put the urls you'd like to check, separated by commas in your conf file.
+Put the urls you'd like to check, separated by commas without spaces in your conf file.
+/etc/munin/plugin-conf.d (sometimes /etc/opt/munin/plugin-conf.d) is where plugin
+configuration files are stored.
+More detils: http://guide.munin-monitoring.org/en/latest/plugin/use.html#configuring
 
 Requires httplib2 for python (easy_install httplib2, or http://code.google.com/p/httplib2/ )
 Graphs the time (in milliseconds) for the response of the url(s) provided.
@@ -58,7 +61,7 @@ def get_printable_url(url):
     will not allow slashes, dots and other characters.
     '''
     import urlparse
-    parsed = urlparse.urlsplit (url)
+    parsed = urlparse.urlsplit(url)
     return ("%s_%s_%s" % (parsed[1] , parsed[2], parsed[3])).replace("/", "_").replace(".", "_").replace('-','_')
 
 def get_request_time(url):
@@ -80,7 +83,7 @@ def get_urls():
     try:
         return os.environ["urls"].split(",")
     except KeyError:
-        print "You needto specify which URLS to monitor by setting the 'urls' env variable in your munin-conf."
+        print "You need to specify which URLS to monitor by setting the 'urls' env variable in your munin-conf."
         sys.exit(1)
 
 def run():


### PR DESCRIPTION
Added hint that there shall be no spaces in the environment variable
New location for config file. The old text vaguely hinted to munin.conf or munin-node.conf which both don't work.
Fixed typos